### PR TITLE
GH-194: Run CI only on `pull_request`

### DIFF
--- a/.github/workflows/consumers.yml
+++ b/.github/workflows/consumers.yml
@@ -1,6 +1,10 @@
 name: Consumers
 
-on: [push]
+on:
+  push:
+    branches:
+      - develop
+  pull_request:
 
 jobs:
   app-mobile:


### PR DESCRIPTION
## Description

Only run CI on `pull_request` (except on `develop` we also do `push`).

### 🔗 Reference

> _Relevant links (e.g. issue, design, etc.)_

closes #194

## 🔎 Reviewer Checklist

> _Checked off by PR **Reviewers**_

- [ ] Merge destination is correct
- [ ] Code is correct as understood and conforms to quality standards
- [ ] Tests have been added where appropriate (unit, visual, end-to-end)
- [ ] Acceptance Criteria have been met

<!--
Optional additions:
- [ ] Code has been tested and confirmed locally
-->

---

> ### Roles & Responsibilities
>
> #### 👨‍💻 Assignee
>
> - Initiator of this PR (be sure to set in GitHub UI)
> - Addresses feedback and change requests
> - Merges PR once approved (usually deletes branch unless `develop` or `release`)
>
> #### 👩‍💻 Reviewer
>
> - Invited to review PR by **Assignee** (via GitHub UI)
> - Is expected to complete a review and address followup

<!--
## Before/After Table

<table>
<tr><th>Before</th><th>After</th></tr>
<tr>
<td>

![](BEFORE_IMAGE_LINK_HERE)

</td>
<td>

![](AFTER_IMAGE_LINK_HERE)

</td>
</tr>
</table>
-->
